### PR TITLE
ASN-197: hex strings are now always uppercase.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.brightsparklabs:assam:0.6.0'
+    compile 'com.brightsparklabs:assam:0.6.1'
     compile "com.google.guava:guava:21.0"
     compile "org.bouncycastle:bcprov-jdk16:1.45"
     def slf4jVersion = "1.7.23"

--- a/src/main/java/com/brightsparklabs/asanti/common/ByteArrays.java
+++ b/src/main/java/com/brightsparklabs/asanti/common/ByteArrays.java
@@ -25,7 +25,7 @@ public class ByteArrays
     // -------------------------------------------------------------------------
 
     /** basic hex encoding in lowercase */
-    private static BaseEncoding hexEncoding = BaseEncoding.base16().lowerCase();
+    private static BaseEncoding hexEncoding = BaseEncoding.base16();
 
     // -------------------------------------------------------------------------
     // CONSTRUCTION
@@ -117,7 +117,8 @@ public class ByteArrays
 
     /**
      * Returns a hex representation of the bytes in the supplied array, with "0x" prepended to it,
-     *  or an empty string if byte array was {@code null} or empty
+     * or an empty string if byte array was {@code null} or empty.  The hex conversion will use an
+     * uppercase alphabet, ie "0xAB" as opposed to "0xab".
      *
      * @param bytes
      *         bytes to decode

--- a/src/main/java/com/brightsparklabs/asanti/model/data/AsantiAsnDataImpl.java
+++ b/src/main/java/com/brightsparklabs/asanti/model/data/AsantiAsnDataImpl.java
@@ -114,8 +114,7 @@ public class AsantiAsnDataImpl implements AsantiAsnData
         this.asnSchema = asnSchema;
         this.decodedTags = ImmutableMap.copyOf(decodedToRawTags);
         this.unmappedTags = ImmutableMap.copyOf(unmappedTags);
-        this.allTags = ImmutableMap.<String, DecodedTag>builder()
-                .putAll(decodedToRawTags)
+        this.allTags = ImmutableMap.<String, DecodedTag>builder().putAll(decodedToRawTags)
                 .putAll(unmappedTags)
                 .build();
     }
@@ -193,7 +192,7 @@ public class AsantiAsnDataImpl implements AsantiAsnData
     @Override
     public Optional<String> getHexString(final String tag)
     {
-        return getBytes(tag).map(bytes -> "0x" + BaseEncoding.base16().encode(bytes));
+        return getBytes(tag).map(bytes -> BaseEncoding.base16().encode(bytes));
     }
 
     @Override
@@ -209,7 +208,7 @@ public class AsantiAsnDataImpl implements AsantiAsnData
         final Map<String, byte[]> raw = rawAsnData.getBytesMatching(regex);
         for (Map.Entry<String, byte[]> entry : raw.entrySet())
         {
-            final String hexString = "0x" + BaseEncoding.base16().encode(entry.getValue());
+            final String hexString = BaseEncoding.base16().encode(entry.getValue());
             result.put(entry.getKey(), hexString);
         }
 

--- a/src/test/groovy/com/brightsparklabs/asanti/common/ByteArraysTest.groovy
+++ b/src/test/groovy/com/brightsparklabs/asanti/common/ByteArraysTest.groovy
@@ -25,7 +25,7 @@ class ByteArraysTest extends Specification {
         (byte[]) [] || ""
         (byte[]) [0] || "0x00"
         (byte[]) [0, 1, 2, 3, 4, 5] || "0x000102030405"
-        (byte[]) [ 'h', 'e', 'l', 'l', 'o' ] || "0x68656c6c6f (\"hello\")"
+        (byte[]) [ 'h', 'e', 'l', 'l', 'o' ] || "0x68656C6C6F (\"hello\")"
     }
 
     def "test containsNonPrintableChars: #input"() {
@@ -65,7 +65,7 @@ class ByteArraysTest extends Specification {
         (byte[]) [] || ""
         (byte[]) [0] || "0x00"
         (byte[]) [0, 1, 2, 3, 4, 5] || "0x000102030405"
-        (byte[]) [ 'h', 'e', 'l', 'l', 'o' ] || "0x68656c6c6f"
+        (byte[]) [ 'h', 'e', 'l', 'l', 'o' ] || "0x68656C6C6F"
     }
 
 }

--- a/src/test/java/com/brightsparklabs/asanti/model/data/AsantiAsnDataImplTest.java
+++ b/src/test/java/com/brightsparklabs/asanti/model/data/AsantiAsnDataImplTest.java
@@ -296,23 +296,23 @@ public class AsantiAsnDataImplTest
     @Test
     public void testGetHexString() throws Exception
     {
-        assertEquals("0x2F312F302F31",
+        assertEquals("2F312F302F31",
                 instance.getHexString("/Document/header/published/date").get());
-        assertEquals("0x2F322F302F30",
+        assertEquals("2F322F302F30",
                 instance.getHexString("/Document/body/lastModified/date").get());
-        assertEquals("0x2F322F312F31", instance.getHexString("/Document/body/prefix/text").get());
-        assertEquals("0x2F322F322F31", instance.getHexString("/Document/body/content/text").get());
-        assertEquals("0x2F332F302F31",
+        assertEquals("2F322F312F31", instance.getHexString("/Document/body/prefix/text").get());
+        assertEquals("2F322F322F31", instance.getHexString("/Document/body/content/text").get());
+        assertEquals("2F332F302F31",
                 instance.getHexString("/Document/footer/authors[0]/firstName").get());
 
         // test unmapped tags
-        assertEquals("0x2F322F302F3939",
+        assertEquals("2F322F302F3939",
                 instance.getHexString("/Document/body/content/0[99]").get());
-        assertEquals("0x2F39392F312F31", instance.getHexString("/Document/0[99]/0[1]/0[1]").get());
+        assertEquals("2F39392F312F31", instance.getHexString("/Document/0[99]/0[1]/0[1]").get());
 
         // test raw tags
-        assertEquals("0x2F322F302F3939", instance.getHexString("1[2]/0[0]/0[99]").get());
-        assertEquals("0x2F39392F312F31", instance.getHexString("0[99]/0[1]/0[1]").get());
+        assertEquals("2F322F302F3939", instance.getHexString("1[2]/0[0]/0[99]").get());
+        assertEquals("2F39392F312F31", instance.getHexString("0[99]/0[1]/0[1]").get());
 
         // test unmapped is the same as respective raw
         assertEquals(instance.getHexString("/Document/body/content/0[99]").get(),
@@ -334,17 +334,17 @@ public class AsantiAsnDataImplTest
         Pattern regex = Pattern.compile("/Document/bod[x-z]/.+");
         ImmutableMap<String, String> result = instance.getHexStringsMatching(regex);
         assertEquals(4, result.size());
-        assertEquals("0x2F322F302F30", result.get("/Document/body/lastModified/date"));
-        assertEquals("0x2F322F312F31", result.get("/Document/body/prefix/text"));
-        assertEquals("0x2F322F322F31", result.get("/Document/body/content/text"));
-        assertEquals("0x2F322F302F3939", result.get("/Document/body/content/0[99]"));
+        assertEquals("2F322F302F30", result.get("/Document/body/lastModified/date"));
+        assertEquals("2F322F312F31", result.get("/Document/body/prefix/text"));
+        assertEquals("2F322F322F31", result.get("/Document/body/content/text"));
+        assertEquals("2F322F302F3939", result.get("/Document/body/content/0[99]"));
         result = emptyInstance.getHexStringsMatching(regex);
         assertEquals(0, result.size());
 
         regex = Pattern.compile("/Document/.\\[\\d{2,4}\\]/\\d+\\[\\d+\\]/\\d\\[1\\]");
         result = instance.getHexStringsMatching(regex);
         assertEquals(1, result.size());
-        assertEquals("0x2F39392F312F31", result.get("/Document/0[99]/0[1]/0[1]"));
+        assertEquals("2F39392F312F31", result.get("/Document/0[99]/0[1]/0[1]"));
         result = emptyInstance.getHexStringsMatching(regex);
         assertEquals(0, result.size());
 
@@ -352,8 +352,8 @@ public class AsantiAsnDataImplTest
         regex = Pattern.compile("1\\[2\\]/0\\[0\\]/.+");
         result = instance.getHexStringsMatching(regex);
         assertEquals(2, result.size());
-        assertEquals("0x2F322F302F30", result.get("1[2]/0[0]/0[0]"));
-        assertEquals("0x2F322F302F3939", result.get("1[2]/0[0]/0[99]"));
+        assertEquals("2F322F302F30", result.get("1[2]/0[0]/0[0]"));
+        assertEquals("2F322F302F3939", result.get("1[2]/0[0]/0[99]"));
         result = emptyInstance.getHexStringsMatching(regex);
         assertEquals(0, result.size());
 

--- a/src/test/java/com/brightsparklabs/asanti/validator/builtin/VisibleStringValidatorTest.java
+++ b/src/test/java/com/brightsparklabs/asanti/validator/builtin/VisibleStringValidatorTest.java
@@ -63,7 +63,7 @@ public class VisibleStringValidatorTest
         assertEquals(1, failures.size());
         DecodedTagValidationFailure failure = failures.iterator().next();
         assertEquals(FailureType.DataIncorrectlyFormatted, failure.getFailureType());
-        assertEquals(BuiltinTypeValidator.VISIBLESTRING_VALIDATION_ERROR + "0x7f00",
+        assertEquals(BuiltinTypeValidator.VISIBLESTRING_VALIDATION_ERROR + "0x7F00",
                 failure.getFailureReason());
 
         // test invalid - constraint
@@ -123,7 +123,7 @@ public class VisibleStringValidatorTest
             assertEquals(1, failures.size());
             final ByteValidationFailure failure = failures.iterator().next();
             assertEquals(FailureType.DataIncorrectlyFormatted, failure.getFailureType());
-            assertEquals(errorPrefix + String.format("0x%02x", b), failure.getFailureReason());
+            assertEquals(errorPrefix + String.format("0x%02X", b), failure.getFailureReason());
         }
 
         bytes[0] = Byte.MAX_VALUE;
@@ -131,7 +131,7 @@ public class VisibleStringValidatorTest
         assertEquals(1, failures.size());
         ByteValidationFailure failure = failures.iterator().next();
         assertEquals(FailureType.DataIncorrectlyFormatted, failure.getFailureType());
-        assertEquals(errorPrefix + "0x7f", failure.getFailureReason());
+        assertEquals(errorPrefix + "0x7F", failure.getFailureReason());
 
         // test empty
         bytes = new byte[0];


### PR DESCRIPTION
getHexString on AsnData does not prepend 0x
Updates tests accordingly.